### PR TITLE
automake -a / Update netperf-enable-demo.rb

### DIFF
--- a/Formula/netperf-enable-demo.rb
+++ b/Formula/netperf-enable-demo.rb
@@ -11,6 +11,7 @@ class NetperfEnableDemo < Formula
       s.gsub! "mach_port_deallocate(lib_host_port);", "mach_port_deallocate(mach_task_self(), lib_host_port);"
     end
 
+    system "automake", "-a"
     system "./configure", "--disable-dependency-tracking",
                           "--enable-demo",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
automake -a = automake --add-missing

This is a suggested step in other builds where the error 

`configure: error: cannot find required auxiliary files: compile`

comes up.
