### PR TITLE
Fix build on Apple Clang / C23 by pinning to -std=gnu17

### DIFF
--- a/Formula/netperf-enable-demo.rb
+++ b/Formula/netperf-enable-demo.rb
@@ -14,9 +14,16 @@ class NetperfEnableDemo < Formula
     end
 
     system "./autogen.sh"
+    # netperf 2.7's headers use K&R empty-paren declarations like
+    # `extern void HIST_purge();`. Modern autoconf + Apple Clang now default to
+    # -std=gnu23, where `()` means "(void)", so every call with arguments fails
+    # with "too many arguments to function call". Pin to gnu17 (the last pre-C23
+    # standard) where K&R declarations still compile. Passing CFLAGS here keeps
+    # the build on gnu17 regardless of which standard the compiler defaults to.
     system "./configure", "--disable-dependency-tracking",
                           "--enable-demo",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "CFLAGS=-std=gnu17"
     system "make", "install"
   end
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This is a slightly modifed formula from the original `netperf` homebrew formula.
 
 1. This homebrew formula also runs `./autogen.sh` during the build process, which is required to get this to build on macOS with the latest source code.
 
+1. Pins the build to the `-std=gnu17` C standard. Recent versions of `autoconf` paired with Apple Clang now default to `-std=gnu23`, where an empty function parameter list (`()`) means "takes no arguments". Netperf's older K&R-style declarations (e.g. `extern void HIST_purge();`) then fail to compile with `too many arguments to function call`. Forcing `gnu17` (the last pre-C23 standard) keeps the build working on modern macOS toolchains (e.g. Apple Clang 21 / Command Line Tools 26).
+
 ## How to install this homebrew formula
 
 ### Method 1 - Recommended


### PR DESCRIPTION
# Fix build on Apple Clang / C23 by pinning to `-std=gnu17`

## Problem

`brew install kris-anderson/netperf/netperf-enable-demo` started failing during `make` with a wall of errors like:

```
nettest_bsd.c:5197:36: error: too many arguments to function call, expected 0, have 4
./netlib.h:679:26: note: 'allocate_buffer_ring' declared here
  679 | extern  struct ring_elt *allocate_buffer_ring();
./hist.h:135:6: error: conflicting types for 'HIST_purge'
```

Nothing in this repo changed — the host toolchain did.

## Root cause

The formula runs `./autogen.sh`, which regenerates `configure` with the current `autoconf`. Modern `autoconf` (2.73) paired with **Apple Clang 21** (Command Line Tools 26) probes for the newest C standard the compiler supports and selects **`-std=gnu23`**, baking it into `CC`.

In **C23, an empty parameter list `()` means `(void)`** — *takes no arguments* — instead of the old K&R "unspecified arguments". Netperf 2.7's headers are full of K&R declarations:

```c
extern struct ring_elt *allocate_buffer_ring();
extern void HIST_purge();
extern void HIST_get_stats();
extern int  HIST_get_percentile();
```

So every call with arguments becomes a hard error (`too many arguments to function call`), and `()` vs `(HIST h)` declarations now "conflict". These are **semantic errors under C23, not warnings** — they can't be silenced with `-Wno-*`. The only fix is to build on a pre-C23 standard.

## Fix

Pass `CFLAGS=-std=gnu17` to `./configure`:

```ruby
system "./configure", "--disable-dependency-tracking",
                      "--enable-demo",
                      "--prefix=#{prefix}",
                      "CFLAGS=-std=gnu17"
```

`gnu17` is the last pre-C23 dialect, so empty-paren K&R declarations compile again (just a benign `-Wdeprecated-non-prototype` warning). Pinning explicitly via `CFLAGS` keeps the build on `gnu17` regardless of which standard the compiler defaults to now or in the future.

## Why this approach

A few options were tested end-to-end through Homebrew; all worked, but this one is the most robust and idiomatic:

| Approach | Result | Notes |
|---|---|---|
| `ac_cv_prog_cc_c23=no` (configure cache var) | ✅ builds | Relies on clang's *default* staying pre-C23 — would break if a future clang defaults to C23 |
| `CFLAGS=-std=gnu17` to `./configure` **(chosen)** | ✅ builds | Explicitly pins gnu17; survives a future C23 default |
| `make … CFLAGS=-std=gnu17` (make-time) | ✅ builds | Works (wins as the last `-std`), but less conventional |

## Testing

Built and verified from source on macOS (Apple Clang 21, CLT 26, Apple Silicon):

- `brew reinstall --build-from-source kris-anderson/netperf/netperf-enable-demo` → builds in ~17s
- `brew test …` → passes
- `netperf -V` → `Netperf version 2.7.1`
- `netperf -D 0.5 …` → the demo-mode flag is accepted, confirming `--enable-demo` is still compiled in

## Also

- README updated with a note explaining the `-std=gnu17` pin.